### PR TITLE
Elements getters and unix timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 /Cargo.lock
+
+snapshots
+node_modules
+generated_bindings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,18 @@ bindings = { wai-version = "0.2.0", exports = "sgp4.wai" }
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[patch.crates-io]
+original = { path = "../../Rust/sgp4", package = "sgp4" }
+
 [dependencies]
 wai-bindgen-rust = "0.2.2"
 original = { version = "0.8.2", package = "sgp4" }
-chrono = "0.4.23"
 
-[patch.crates-io]
-original = { path = "../../Rust/sgp4", package = "sgp4" }
+[dev-dependencies]
+anyhow = "1.0.68"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+wasmer-pack-testing = "0.6.0"
+
+[[test]]
+name = "sgp4-integration-tests"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wai-bindgen-rust = "0.2.2"
 original = { version = "0.8.2", package = "sgp4" }
+
+[patch.crates-io]
+original = { path = "../../Rust/sgp4", package = "sgp4" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wai-bindgen-rust = "0.2.2"
 original = { version = "0.8.2", package = "sgp4" }
+chrono = "0.4.23"
 
 [patch.crates-io]
 original = { path = "../../Rust/sgp4", package = "sgp4" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wai-bindgen-rust = "0.2.2"
+original = { version = "0.8.2", package = "sgp4" }

--- a/sgp4.test.js
+++ b/sgp4.test.js
@@ -1,0 +1,6 @@
+const { bindings } = require("@wasmer/sgp4");
+const { Elements } = require("@wasmer/sgp4/src/bindings/sgp4/sgp4.js");
+
+test("Sample Test", () => {
+  expect(1).toBe(1);
+});

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -71,7 +71,7 @@ variant classification {
 
 /// Elements Struct, ⚠️ we are keeping datetime as a string 
 
-record elements-s {
+record element-s {
     object-name: option<string>,
     international-designator: option<string>,
     norad-id: u64,
@@ -135,18 +135,14 @@ wgs84: func() -> geopotential
 
 afspc-epoch-to-sidereal-time: func(epoch: float64) -> float64
 iau-epoch-to-sidereal-time: func(epoch: float64) -> float64
-parse2les: func(tles: string) -> expected<list<elements-s>,error>
-parse3les: func(tles: string) -> expected<list<elements-s>,error> 
+parse2les: func(tles: string) -> expected<list<element-s>,error>
+parse3les: func(tles: string) -> expected<list<element-s>,error> 
 
 
-
-record resonance-state {
-    t: float64,
-    mean-motion: float64,
-    lambda: float64,
+// get the t from resonanceState as all the fields are private and doeesn't allow automatic initialization
+resource resonance-state {
+    t: func()->float64
 }
-
-resonance-state-t: func(rs: resonance-state) -> float64
 
 
 enum epoch-to-sidereal-time-algorithm {
@@ -157,8 +153,8 @@ enum epoch-to-sidereal-time-algorithm {
 /// implmenetation for Constants
 resource constants {
     static new: func(geopotential: geopotential, epoch-to-sidereal-time: epoch-to-sidereal-time-algorithm, epoch: float64, drag-item: float64, orbit0: orbit) -> expected<constants, error>
-    static from-elements: func(elements: elements-s) -> expected<constants, error>
-    static from-elements-afspc-compatibility-mode: func(elements: elements-s) -> expected<constants, error>
+    static from-elements: func(elements: element-s) -> expected<constants, error>
+    static from-elements-afspc-compatibility-mode: func(elements: element-s) -> expected<constants, error>
     initial-state: func() -> option<resonance-state>
     propagate-from-state: func(t: float64, state: option<resonance-state>, afspc-compatibility-mode: bool) -> expected<prediction, error>
     propagate: func(t: float64) -> expected<prediction, error>

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -1,6 +1,5 @@
 // sgp4.wai
 
-
 /// underlying structs and variants for errors
 variant error-tle-what {
     bad-checksum,
@@ -36,11 +35,6 @@ record out-of-range-perturbed-eccentricity {
     t: float64,
 }
 
-record unix-timestamp {
-    secs: s64,
-    nanos: u32
-}
-
 record negative-semi-latus-rectum {
     t: float64,
 }
@@ -73,28 +67,6 @@ variant classification {
 
 
 
-
-/// Elements Struct, ⚠️ we are keeping datetime as a string 
-
-record element-s {
-    object-name: option<string>,
-    international-designator: option<string>,
-    norad-id: u64,
-    classification: classification,
-    datetime: string,
-    mean-motion-dot: float64,
-    mean-motion-ddot: float64,
-    drag-term: float64,
-    element-set-number: u64,
-    inclination: float64,
-    right-ascension: float64,
-    eccentricity: float64,
-    argument-of-perigee: float64,
-    mean-anomaly: float64,
-    mean-motion: float64,
-    revolution-number: u64,
-    ephemeris-type: u8,
-}
 
 resource elements {
     static from-tle: func(object-name: option<string>, line1: string, line2: string) -> expected<elements,error>
@@ -140,8 +112,8 @@ wgs84: func() -> geopotential
 
 afspc-epoch-to-sidereal-time: func(epoch: float64) -> float64
 iau-epoch-to-sidereal-time: func(epoch: float64) -> float64
-parse2les: func(tles: string) -> expected<list<element-s>,error>
-parse3les: func(tles: string) -> expected<list<element-s>,error> 
+parse2les: func(tles: string) -> expected<list<elements>,error>
+parse3les: func(tles: string) -> expected<list<elements>,error> 
 
 
 // get the t from resonanceState as all the fields are private and doeesn't allow automatic initialization
@@ -158,8 +130,8 @@ enum epoch-to-sidereal-time-algorithm {
 /// implmenetation for Constants
 resource constants {
     static new: func(geopotential: geopotential, epoch-to-sidereal-time: epoch-to-sidereal-time-algorithm, epoch: float64, drag-item: float64, orbit0: orbit) -> expected<constants, error>
-    static from-elements: func(elements: element-s) -> expected<constants, error>
-    static from-elements-afspc-compatibility-mode: func(elements: element-s) -> expected<constants, error>
+    static from-elements: func(elements: elements) -> expected<constants, error>
+    static from-elements-afspc-compatibility-mode: func(elements: elements) -> expected<constants, error>
     initial-state: func() -> option<resonance-state>
     propagate-from-state: func(t: float64, state: option<resonance-state>, afspc-compatibility-mode: bool) -> expected<prediction, error>
     propagate: func(t: float64) -> expected<prediction, error>

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -58,20 +58,38 @@ variant error {
     tle(tle),
 }
 
-/// Classification variant
-variant classification {
-    unclassified,
-    classified,
-    secret
+record unix-timestamp {
+    secs: s64, 
+    nsecs: u32
 }
 
-
-
+enum classification {
+    unclassified,
+    classified,
+    secret,
+}
 
 resource elements {
     static from-tle: func(object-name: option<string>, line1: string, line2: string) -> expected<elements,error>
     epoch: func() -> float64
     epoch-afspc-compatibility-mode: func() -> float64
+    get-object-name: func() -> option<string>
+    get-international-designator: func() -> option<string>
+    get-norad-id: func() -> u64
+    get-classification: func() -> classification 
+    get-datetime: func() -> unix-timestamp
+    get-mean-motion-dot: func() -> float64
+    get-mean-motion-ddot: func() -> float64
+    get-drag-term: func() -> float64
+    get-element-set-number: func() -> u64 
+    get-inclination: func() -> float64 
+    get-right-ascension: func() -> float64 
+    get-eccentricity: func() -> float64 
+    get-argument-of-perigee: func() -> float64 
+    get-mean-anomaly: func() -> float64 
+    get-mean-motion: func() -> float64 
+    get-revolution-number: func() -> u64 
+    get-ephemeris-type: func() -> u8
 }
 
 

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -2,7 +2,7 @@
 
 
 /// underlying structs and variants for errors
-variant error-tle-what-var {
+variant error-tle-what {
     bad-checksum,
     bad-length,
     bad-first-character,
@@ -16,33 +16,33 @@ variant error-tle-what-var {
     unknown-classification,
 }
 
-variant error-tle-line-var {
+variant error-tle-line {
     line1,
     line2,
     both,
 }
 
-record out-of-range-epoch-eccentricity-rec {
+record out-of-range-epoch-eccentricity {
     eccentricity: float64,
 }
 
-record out-of-range-eccentricity-rec {
-    eccentricity: float64,
-    t: float64,
-}
-
-record out-of-range-perturbed-eccentricity-rec {
+record out-of-range-eccentricity {
     eccentricity: float64,
     t: float64,
 }
 
-record negative-semi-latus-rectum-rec {
+record out-of-range-perturbed-eccentricity {
+    eccentricity: float64,
     t: float64,
 }
 
-record tle-rec {
-    what: error-tle-what-var,
-    line: error-tle-line-var,
+record negative-semi-latus-rectum {
+    t: float64,
+}
+
+record tle {
+    what: error-tle-what,
+    line: error-tle-line,
     start: u32,
     end: u32,
 }
@@ -50,13 +50,13 @@ record tle-rec {
 
 /// main error variant
 variant error {
-    out-of-range-epoch-eccentricity(out-of-range-epoch-eccentricity-rec),
-    out-of-range-eccentricity(out-of-range-eccentricity-rec),
-    out-of-range-perturbed-eccentricity(out-of-range-perturbed-eccentricity-rec),
+    out-of-range-epoch-eccentricity(out-of-range-epoch-eccentricity),
+    out-of-range-eccentricity(out-of-range-eccentricity),
+    out-of-range-perturbed-eccentricity(out-of-range-perturbed-eccentricity),
     negative-brouwer-mean-motion,
     negative-kozai-mean-motion,
-    negative-semi-latus-rectum(negative-semi-latus-rectum-rec),
-    tle(tle-rec),
+    negative-semi-latus-rectum(negative-semi-latus-rectum),
+    tle(tle),
 }
 
 /// Classification variant

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -36,6 +36,11 @@ record out-of-range-perturbed-eccentricity {
     t: float64,
 }
 
+record unix-timestamp {
+    secs: s64,
+    nanos: u32
+}
+
 record negative-semi-latus-rectum {
     t: float64,
 }

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -127,8 +127,10 @@ record prediction {
 }
 
 
-
+/// Constant WGS72
 wgs72: func() -> geopotential
+
+/// Constant WGS84
 wgs84: func() -> geopotential
 
 afspc-epoch-to-sidereal-time: func(epoch: float64) -> float64
@@ -147,12 +149,14 @@ record resonance-state {
 resonance-state-t: func(rs: resonance-state) -> float64
 
 
-
+enum epoch-to-sidereal-time-algorithm {
+  afspc,
+  iau,
+}
 
 /// implmenetation for Constants
 resource constants {
-    static new-with-afspc-epoch-to-sidereal-time: func(geopotential: geopotential, epoch: float64, drag-item: float64, orbit0: orbit) -> expected<constants, error>
-    static new-with-iau-epoch-to-sidereal-time: func(geopotential: geopotential, epoch: float64, drag-item: float64, orbit0: orbit) -> expected<constants, error>
+    static new: func(geopotential: geopotential, epoch-to-sidereal-time: epoch-to-sidereal-time-algorithm, epoch: float64, drag-item: float64, orbit0: orbit) -> expected<constants, error>
     static from-elements: func(elements: elements-s) -> expected<constants, error>
     static from-elements-afspc-compatibility-mode: func(elements: elements-s) -> expected<constants, error>
     initial-state: func() -> option<resonance-state>
@@ -160,5 +164,3 @@ resource constants {
     propagate: func(t: float64) -> expected<prediction, error>
     propagate-afspc-compatibility-mode: func(t: float64) -> expected<prediction, error>
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,115 @@
+use crate::sgp4::{
+    Classification, ElementsS, Error as SgpError, Geopotential, Orbit, Prediction, ResonanceState,
+};
+
+use wai_bindgen_rust::Handle;
 wai_bindgen_rust::export!("sgp4.wai");
+
+struct Sgp4;
+
+impl sgp4::Sgp4 for Sgp4 {
+    fn orbit_from_kozai_elements(
+        geopotential: Geopotential,
+        inclination: f64,
+        right_ascension: f64,
+        eccentricity: f64,
+        argument_of_perigee: f64,
+        mean_anomaly: f64,
+        kozai_mean_motion: f64,
+    ) -> Result<Orbit, SgpError> {
+        todo!()
+    }
+
+    fn wgs72() -> Geopotential {
+        todo!()
+    }
+
+    fn wgs84() -> Geopotential {
+        todo!()
+    }
+
+    fn afspc_epoch_to_sidereal_time(epoch: f64) -> f64 {
+        todo!()
+    }
+
+    fn iau_epoch_to_sidereal_time(epoch: f64) -> f64 {
+        todo!()
+    }
+
+    fn parse2les(tles: String) -> Result<Vec<ElementsS>, SgpError> {
+        todo!()
+    }
+
+    fn parse3les(tles: String) -> Result<Vec<ElementsS>, SgpError> {
+        todo!()
+    }
+
+    fn resonance_state_t(rs: ResonanceState) -> f64 {
+        todo!()
+    }
+}
+
+struct Constants;
+
+impl sgp4::Constants for Constants {
+    fn new(
+        geopotential: Geopotential,
+        epoch_to_sidereal_time: sgp4::EpochToSiderealTimeAlgorithm,
+        epoch: f64,
+        drag_item: f64,
+        orbit0: Orbit,
+    ) -> Result<Handle<crate::Constants>, SgpError> {
+        todo!()
+    }
+
+    fn from_elements(elements: ElementsS) -> Result<Handle<crate::Constants>, SgpError> {
+        todo!()
+    }
+
+    fn from_elements_afspc_compatibility_mode(
+        elements: ElementsS,
+    ) -> Result<Handle<crate::Constants>, SgpError> {
+        todo!()
+    }
+
+    fn initial_state(&self) -> Option<ResonanceState> {
+        todo!()
+    }
+
+    fn propagate_from_state(
+        &self,
+        t: f64,
+        state: Option<ResonanceState>,
+        afspc_compatibility_mode: bool,
+    ) -> Result<Prediction, SgpError> {
+        todo!()
+    }
+
+    fn propagate(&self, t: f64) -> Result<Prediction, SgpError> {
+        todo!()
+    }
+
+    fn propagate_afspc_compatibility_mode(&self, t: f64) -> Result<Prediction, SgpError> {
+        todo!()
+    }
+}
+
+struct Elements(ElementsS);
+
+impl sgp4::Elements for Elements {
+    fn from_tle(
+        object_name: Option<String>,
+        line1: String,
+        line2: String,
+    ) -> Result<Handle<crate::Elements>, SgpError> {
+        todo!()
+    }
+
+    fn epoch(&self) -> f64 {
+        todo!()
+    }
+
+    fn epoch_afspc_compatibility_mode(&self) -> f64 {
+        todo!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 use crate::sgp4::{
-    Classification, ElementsS, Error as SgpError, Geopotential, Orbit, Prediction, ResonanceState,
+    Classification, ElementsS, Error as SgpError, ErrorTleLine, ErrorTleWhat, Geopotential,
+    NegativeSemiLatusRectum, Orbit, OutOfRangeEccentricity, OutOfRangeEpochEccentricity,
+    OutOfRangePerturbedEccentricity, Prediction, ResonanceState, Tle,
 };
+
+use original::{self};
 
 use wai_bindgen_rust::Handle;
 wai_bindgen_rust::export!("sgp4.wai");
@@ -21,22 +25,23 @@ impl sgp4::Sgp4 for Sgp4 {
     }
 
     fn wgs72() -> Geopotential {
-        todo!()
+        original::WGS72.into()
     }
 
     fn wgs84() -> Geopotential {
-        todo!()
+        original::WGS72.into()
     }
 
     fn afspc_epoch_to_sidereal_time(epoch: f64) -> f64 {
-        todo!()
+        original::afspc_epoch_to_sidereal_time(epoch)
     }
 
     fn iau_epoch_to_sidereal_time(epoch: f64) -> f64 {
-        todo!()
+        original::iau_epoch_to_sidereal_time(epoch)
     }
 
     fn parse2les(tles: String) -> Result<Vec<ElementsS>, SgpError> {
+        // original::parse_2les(&tles)
         todo!()
     }
 
@@ -58,17 +63,17 @@ impl sgp4::Constants for Constants {
         epoch: f64,
         drag_item: f64,
         orbit0: Orbit,
-    ) -> Result<Handle<crate::Constants>, SgpError> {
+    ) -> Result<Handle<Constants>, SgpError> {
         todo!()
     }
 
-    fn from_elements(elements: ElementsS) -> Result<Handle<crate::Constants>, SgpError> {
+    fn from_elements(elements: ElementsS) -> Result<Handle<Constants>, SgpError> {
         todo!()
     }
 
     fn from_elements_afspc_compatibility_mode(
         elements: ElementsS,
-    ) -> Result<Handle<crate::Constants>, SgpError> {
+    ) -> Result<Handle<Constants>, SgpError> {
         todo!()
     }
 
@@ -101,7 +106,7 @@ impl sgp4::Elements for Elements {
         object_name: Option<String>,
         line1: String,
         line2: String,
-    ) -> Result<Handle<crate::Elements>, SgpError> {
+    ) -> Result<Handle<Elements>, SgpError> {
         todo!()
     }
 
@@ -111,5 +116,100 @@ impl sgp4::Elements for Elements {
 
     fn epoch_afspc_compatibility_mode(&self) -> f64 {
         todo!()
+    }
+}
+
+impl From<original::Geopotential> for Geopotential {
+    fn from(original_geopotential: original::Geopotential) -> Self {
+        let original::Geopotential { ae, ke, j2, j3, j4 } = original_geopotential;
+        Geopotential { ae, ke, j2, j3, j4 }
+    }
+}
+
+impl From<original::Classification> for Classification {
+    fn from(classification: original::Classification) -> Self {
+        match classification {
+            original::Classification::Unclassified => Classification::Unclassified,
+            original::Classification::Classified => Classification::Classified,
+            original::Classification::Secret => Classification::Secret,
+        }
+    }
+}
+
+impl From<original::Error> for SgpError {
+    fn from(e: original::Error) -> Self {
+        match e {
+            original::Error::OutOfRangeEpochEccentricity { eccentricity } => {
+                SgpError::OutOfRangeEpochEccentricity(OutOfRangeEpochEccentricity { eccentricity })
+            }
+            original::Error::OutOfRangeEccentricity { eccentricity, t } => {
+                SgpError::OutOfRangeEccentricity(OutOfRangeEccentricity { eccentricity, t })
+            }
+            original::Error::OutOfRangePerturbedEccentricity { eccentricity, t } => {
+                SgpError::OutOfRangePerturbedEccentricity(OutOfRangePerturbedEccentricity {
+                    eccentricity,
+                    t,
+                })
+            }
+            original::Error::NegativeBrouwerMeanMotion => SgpError::NegativeBrouwerMeanMotion,
+            original::Error::NegativeKozaiMeanMotion => SgpError::NegativeKozaiMeanMotion,
+            original::Error::NegativeSemiLatusRectum { t } => {
+                SgpError::NegativeSemiLatusRectum(NegativeSemiLatusRectum { t })
+            }
+            original::Error::Tle {
+                what,
+                line,
+                start,
+                end,
+            } => SgpError::Tle(Tle {
+                what: todo!(),
+                line: todo!(),
+                start: start.try_into().unwrap(),
+                end: end.try_into().unwrap(),
+            }),
+        }
+    }
+}
+
+impl From<original::Elements> for ElementsS {
+    fn from(elements: original::Elements) -> Self {
+        let original::Elements {
+            object_name,
+            international_designator,
+            norad_id,
+            classification,
+            datetime,
+            mean_motion_dot,
+            mean_motion_ddot,
+            drag_term,
+            element_set_number,
+            inclination,
+            right_ascension,
+            eccentricity,
+            argument_of_perigee,
+            mean_anomaly,
+            mean_motion,
+            revolution_number,
+            ephemeris_type,
+        } = elements;
+        ElementsS {
+            object_name,
+            international_designator,
+            norad_id,
+            classification: classification.into(),
+            datetime: datetime.to_string(),
+            mean_motion_dot,
+            mean_motion_ddot,
+            drag_term,
+            element_set_number,
+            inclination,
+            right_ascension,
+            eccentricity,
+            argument_of_perigee,
+            mean_anomaly,
+            mean_motion,
+            revolution_number,
+            ephemeris_type,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,7 @@ impl sgp4::Sgp4 for Sgp4 {
     }
 
     fn parse2les(tles: String) -> Result<Vec<ElementsS>, SgpError> {
-        // original::parse_2les(&tles)
-        todo!()
+        let converted_vec: Vec<ElementsS> = original::parse_2les(&tles);
     }
 
     fn parse3les(tles: String) -> Result<Vec<ElementsS>, SgpError> {
@@ -136,6 +135,38 @@ impl From<original::Classification> for Classification {
     }
 }
 
+impl From<original::ErrorTleLine> for ErrorTleLine {
+    fn from(e: original::ErrorTleLine) -> Self {
+        match e {
+            original::ErrorTleLine::Line1 => ErrorTleLine::Line1,
+            original::ErrorTleLine::Line2 => ErrorTleLine::Line2,
+            original::ErrorTleLine::Both => ErrorTleLine::Both,
+        }
+    }
+}
+
+impl From<original::ErrorTleWhat> for ErrorTleWhat {
+    fn from(e: original::ErrorTleWhat) -> Self {
+        match e {
+            original::ErrorTleWhat::BadChecksum => ErrorTleWhat::BadChecksum,
+            original::ErrorTleWhat::BadLength => ErrorTleWhat::BadLength,
+            original::ErrorTleWhat::BadFirstCharacter => ErrorTleWhat::BadFirstCharacter,
+            original::ErrorTleWhat::ExpectedFloat => ErrorTleWhat::ExpectedFloat,
+            original::ErrorTleWhat::ExpectedFloatWithAssumedDecimalPoint => {
+                ErrorTleWhat::ExpectedFloatWithAssumedDecimalPoint
+            }
+            original::ErrorTleWhat::ExpectedInteger => ErrorTleWhat::ExpectedInteger,
+            original::ErrorTleWhat::ExpectedSpace => ErrorTleWhat::ExpectedSpace,
+            original::ErrorTleWhat::ExpectedString => ErrorTleWhat::ExpectedString,
+            original::ErrorTleWhat::FloatWithAssumedDecimalPointTooLong => {
+                ErrorTleWhat::FloatWithAssumedDecimalPointTooLong
+            }
+            original::ErrorTleWhat::NoradIdMismatch => ErrorTleWhat::NoradIdMismatch,
+            original::ErrorTleWhat::UnknownClassification => ErrorTleWhat::UnknownClassification,
+        }
+    }
+}
+
 impl From<original::Error> for SgpError {
     fn from(e: original::Error) -> Self {
         match e {
@@ -162,8 +193,8 @@ impl From<original::Error> for SgpError {
                 start,
                 end,
             } => SgpError::Tle(Tle {
-                what: todo!(),
-                line: todo!(),
+                what: what.into(),
+                line: line.into(),
                 start: start.try_into().unwrap(),
                 end: end.try_into().unwrap(),
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ use std::sync::Mutex;
 use wai_bindgen_rust::Handle;
 
 use crate::sgp4::{
-    EpochToSiderealTimeAlgorithm, Error as SgpError, ErrorTleLine, ErrorTleWhat, Geopotential,
-    NegativeSemiLatusRectum, Orbit, OutOfRangeEccentricity, OutOfRangeEpochEccentricity,
-    OutOfRangePerturbedEccentricity, Prediction, Tle,
+    Classification, EpochToSiderealTimeAlgorithm, Error as SgpError, ErrorTleLine, ErrorTleWhat,
+    Geopotential, NegativeSemiLatusRectum, Orbit, OutOfRangeEccentricity,
+    OutOfRangeEpochEccentricity, OutOfRangePerturbedEccentricity, Prediction, Tle, UnixTimestamp,
 };
 
 use original::{self};
@@ -66,7 +66,7 @@ impl sgp4::Sgp4 for Sgp4 {
     }
 }
 
-struct ResonanceState(Mutex<original::ResonanceState>);
+pub struct ResonanceState(Mutex<original::ResonanceState>);
 impl ResonanceState {
     fn new(state: original::ResonanceState) -> Self {
         ResonanceState(Mutex::new(state))
@@ -79,8 +79,7 @@ impl sgp4::ResonanceState for ResonanceState {
     }
 }
 
-struct Constants(original::Constants);
-
+pub struct Constants(original::Constants);
 impl Constants {
     fn new_wrap(state: original::Constants) -> Self {
         Constants(state)
@@ -155,8 +154,7 @@ impl sgp4::Constants for Constants {
     }
 }
 
-struct Elements(original::Elements);
-
+pub struct Elements(original::Elements);
 impl Elements {
     fn new(state: original::Elements) -> Self {
         Elements(state)
@@ -180,7 +178,80 @@ impl sgp4::Elements for Elements {
     fn epoch_afspc_compatibility_mode(&self) -> f64 {
         self.0.epoch_afspc_compatibility_mode()
     }
+
+    fn get_object_name(&self) -> Option<String> {
+        self.0.object_name.clone()
+    }
+
+    fn get_international_designator(&self) -> Option<String> {
+        self.0.international_designator.clone()
+    }
+
+    fn get_norad_id(&self) -> u64 {
+        self.0.norad_id
+    }
+
+    fn get_classification(&self) -> Classification {
+        Classification::from(&self.0.classification)
+    }
+
+    fn get_datetime(&self) -> UnixTimestamp {
+        UnixTimestamp {
+            secs: self.0.datetime.timestamp(),
+            nsecs: self.0.datetime.timestamp_subsec_nanos(),
+        }
+    }
+
+    fn get_mean_motion_dot(&self) -> f64 {
+        self.0.mean_motion_dot
+    }
+
+    fn get_mean_motion_ddot(&self) -> f64 {
+        self.0.mean_motion_ddot
+    }
+
+    fn get_drag_term(&self) -> f64 {
+        self.0.drag_term
+    }
+
+    fn get_element_set_number(&self) -> u64 {
+        self.0.element_set_number
+    }
+
+    fn get_inclination(&self) -> f64 {
+        self.0.inclination
+    }
+
+    fn get_right_ascension(&self) -> f64 {
+        self.0.right_ascension
+    }
+
+    fn get_eccentricity(&self) -> f64 {
+        self.0.eccentricity
+    }
+
+    fn get_argument_of_perigee(&self) -> f64 {
+        self.0.argument_of_perigee
+    }
+
+    fn get_mean_anomaly(&self) -> f64 {
+        self.0.mean_anomaly
+    }
+
+    fn get_mean_motion(&self) -> f64 {
+        self.0.mean_anomaly
+    }
+
+    fn get_revolution_number(&self) -> u64 {
+        self.0.revolution_number
+    }
+
+    fn get_ephemeris_type(&self) -> u8 {
+        self.0.ephemeris_type
+    }
 }
+
+// From traits for conversion from original to self and vice-versa
 
 impl From<original::Prediction> for Prediction {
     fn from(prediction: original::Prediction) -> Self {
@@ -339,5 +410,15 @@ impl From<original::Elements> for Elements {
 impl From<Elements> for original::Elements {
     fn from(elements: Elements) -> Self {
         elements.0
+    }
+}
+
+impl From<&original::Classification> for Classification {
+    fn from(classification: &original::Classification) -> Self {
+        match classification {
+            original::Classification::Unclassified => Classification::Unclassified,
+            original::Classification::Classified => Classification::Classified,
+            original::Classification::Secret => Classification::Secret,
+        }
     }
 }

--- a/tests/sgp4-integration-tests.rs
+++ b/tests/sgp4-integration-tests.rs
@@ -1,0 +1,10 @@
+use anyhow::Error;
+use tracing_subscriber::EnvFilter;
+
+fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+    wasmer_pack_testing::autodiscover(env!("CARGO_MANIFEST_DIR"))?;
+    Ok(())
+}


### PR DESCRIPTION
Created getters for elements fields:
 - [x] object_name
 - [x] international_designator
 - [x] norad_id
 - [x] classification
 - [x] datetime
 - [x] mean_motion_dot
 - [x] mean_motion_ddot
 - [x] drag_term
 - [x] element_set_number
 - [x] inclination
 - [x] right_ascension
 - [x] eccentricity
 - [x] argument_of_perigee
 - [x] mean_anomaly
 - [x] mean_motion
 - [x] revolution_number
 - [x] ephemeris_type


Created a new record `unix-timestamp` for the return type of `datetime`.

closes #9


