### PR TITLE
Use `sgp4` from crates.io again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,14 +320,15 @@ name = "sgp4"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "sgp4 0.8.2",
+ "sgp4 0.9.1",
  "wai-bindgen-rust",
 ]
 
 [[package]]
 name = "sgp4"
-version = "0.8.2"
-source = "git+https://github.com/dynamite-bud/sgp4.git#4bc441d29903b703cc85709224397a9468f2c96d"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375c65e48ba1bf0f964f91cac83339b5294888e9605d882a1646f7eaebbcc498"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,5 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wai-bindgen-rust = "0.2.2"
-original = { version = "0.8.2", package = "sgp4" }
+original = { version = "0.9.1", package = "sgp4" }
 chrono = "0.4.23"
-
-[patch.crates-io]
-original = { git = "https://github.com/dynamite-bud/sgp4.git", package = "sgp4" }

--- a/sgp4.wai
+++ b/sgp4.wai
@@ -13,6 +13,8 @@ variant error-tle-what {
     float-with-assumed-decimal-point-too-long,
     norad-id-mismatch,
     unknown-classification,
+    from-yo-opt-failed,
+    from-num-seconds-from-midnight-failed,
 }
 
 variant error-tle-line {
@@ -113,7 +115,7 @@ wgs84: func() -> geopotential
 afspc-epoch-to-sidereal-time: func(epoch: float64) -> float64
 iau-epoch-to-sidereal-time: func(epoch: float64) -> float64
 parse2les: func(tles: string) -> expected<list<elements>,error>
-parse3les: func(tles: string) -> expected<list<elements>,error> 
+parse3les: func(tles: string) -> expected<list<elements>,error>
 
 
 // get the t from resonanceState as all the fields are private and doeesn't allow automatic initialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,10 @@ impl From<original::ErrorTleWhat> for ErrorTleWhat {
             }
             original::ErrorTleWhat::NoradIdMismatch => ErrorTleWhat::NoradIdMismatch,
             original::ErrorTleWhat::UnknownClassification => ErrorTleWhat::UnknownClassification,
+            original::ErrorTleWhat::FromYoOptFailed => ErrorTleWhat::FromYoOptFailed,
+            original::ErrorTleWhat::FromNumSecondsFromMidnightFailed => {
+                ErrorTleWhat::FromNumSecondsFromMidnightFailed
+            }
         }
     }
 }


### PR DESCRIPTION
In #5 we needed to use a forked version of the `sgp4` crate because a couple types hadn't been exported. Now that https://github.com/neuromorphicsystems/sgp4/pull/8 is live, the `[patch]` section isn't necessary and we can switch back to crates.io.